### PR TITLE
FIX: show encoder timepackets + erase prev trace logs only with trace flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ autom4te.cache/
 .gdb_history
 .#*
 *~
+*.log
+*.bin

--- a/riscv/execute.cc
+++ b/riscv/execute.cc
@@ -166,7 +166,7 @@ static inline reg_t execute_insn_fast(processor_t* p, reg_t pc, insn_fetch_t fet
   return fetch.func(p, fetch.insn, pc);
 }
 
-static inline reg_t execute_insn_logged(processor_t* p, reg_t pc, insn_fetch_t fetch)
+static inline reg_t execute_insn_logged(processor_t* p, reg_t pc, insn_fetch_t fetch, size_t instret)
 {
   if (p->get_log_commits_enabled()) {
     commit_log_reset(p);
@@ -188,7 +188,8 @@ static inline reg_t execute_insn_logged(processor_t* p, reg_t pc, insn_fetch_t f
         .i_addr = pc,
         .iretire = 1,
         .ilastsize = insn_length(fetch.insn.bits())/2,
-        .i_timestamp = p->get_state()->mcycle->read(),
+        // .i_timestamp = p->get_state()->mcycle->read(),
+        .i_timestamp = instret,
         };
         p->trace_encoder.push_ingress(packet);
       }
@@ -304,7 +305,7 @@ void processor_t::step(size_t n)
           insn_fetch_t fetch = mmu->load_insn(pc);
           if (debug && !state.serialized)
             disasm(fetch.insn);
-          pc = execute_insn_logged(this, pc, fetch);
+          pc = execute_insn_logged(this, pc, fetch, instret);
           advance_pc();
 
           // Resume from debug mode in critical error

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -186,6 +186,9 @@ void processor_t::enable_log_commits()
 void processor_t::enable_trace()
 {
   trace_enabled = true;
+
+  // if trace flag is true, touch the file, otherwise leave it -- don't do in encoder ∵ encoder enable/disable toggles mid process
+  trace_encoder.init_trace_file();
 }
 
 void processor_t::reset()

--- a/riscv/trace_encoder_l.cc
+++ b/riscv/trace_encoder_l.cc
@@ -16,6 +16,12 @@ bool trace_encoder_l::get_enable() {
   return this->enabled;
 }
 
+void trace_encoder_l::init_trace_file()
+{
+  this->trace_sink = fopen("trace_l.bin", "wb");
+  this->debug_reference = fopen("trace_l_ref_debug.log", "wb");
+}
+
 void trace_encoder_l::push_ingress(hart_to_encoder_ingress_t packet) {
   this->ingress_1 = this->ingress_0;
   this->ingress_0 = packet;

--- a/riscv/trace_encoder_l.h
+++ b/riscv/trace_encoder_l.h
@@ -59,14 +59,14 @@ c_header_t get_c_header(f_header_t f_header);
 class trace_encoder_l {
 public:
   trace_encoder_l() {
-    this->trace_sink = fopen("trace_l.bin", "wb");
-    this->debug_reference = fopen("trace_l_ref_debug.log", "wb");
     this->active = true;
     this->enabled = false;
     this->ingress_0 = hart_to_encoder_ingress_t();
     this->ingress_1 = hart_to_encoder_ingress_t();
     this->state = TRACE_ENCODER_L_IDLE;
   }
+  
+  void init_trace_file();
   void reset();
   void set_enable(bool enabled);
   bool get_enable();


### PR DESCRIPTION
Two fixes here:
1. Make timepackets non-zero by using # instructions retired as a time metric
2. Change so that previous encoder logs only get erased when another spike command is run with `--trace`, otherwise leave the file alone.
    - previous behavior: running without `--trace` would erase the data written to the trace log files